### PR TITLE
fix: Enable connection to work with multiple different credentials

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,59 +1,61 @@
 import { config, Credentials } from 'aws-sdk/global'
 import { request, ClientRequest, ClientRequestArgs } from 'http'
 import { sign } from 'aws4'
-import { Connection, Transport } from '@elastic/elasticsearch'
+import { ClientOptions, Connection, Transport } from '@elastic/elasticsearch'
 import { ApiResponse, TransportRequestPromise } from '@elastic/elasticsearch/lib/Transport'
 
-class AWSConnection extends Connection {
-  public awsCredentials
+function generateAWSConnectionClass(credentials: Credentials) {
+  return class AWSConnection extends Connection {
+    public constructor(opts) {
+      super(opts)
+      this.makeRequest = this.signedRequest
+    }
 
-  public constructor(opts) {
-    super(opts)
-    this.makeRequest = this.signedRequest
-  }
-
-  private signedRequest(reqParams: ClientRequestArgs): ClientRequest {
-    return request(sign(reqParams, this.awsCredentials))
+    private signedRequest(reqParams: ClientRequestArgs): ClientRequest {
+      return request(sign(reqParams, credentials))
+    }
   }
 }
 
-class AWSTransport extends Transport {
-  public request(params, options, callback = undefined) {
-    if (typeof options === 'function') {
-      callback = options
-      options = {}
-    }
-    if (typeof params === 'function' || params == null) {
-      callback = params
-      params = {}
-      options = {}
-    }
-    // Wrap promise API
-    const isPromiseCall = typeof callback !== 'function'
-    if (isPromiseCall) {
-      return (config.credentials as Credentials)
-        .getPromise()
-        .then(() => super.request(params, options, callback)) as TransportRequestPromise<
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        ApiResponse<Record<string, any>, Record<string, unknown>>
-      >
-    }
-
-    //Wrap callback API
-    ;(config.credentials as Credentials).get(err => {
-      if (err) {
-        callback(err, null)
-        return
+function generateAWSTransportClass(credentials: Credentials) {
+  return class AWSTransport extends Transport {
+    public request(params, options, callback = undefined) {
+      if (typeof options === 'function') {
+        callback = options
+        options = {}
+      }
+      if (typeof params === 'function' || params == null) {
+        callback = params
+        params = {}
+        options = {}
+      }
+      // Wrap promise API
+      const isPromiseCall = typeof callback !== 'function'
+      if (isPromiseCall) {
+        return credentials.getPromise().then(() => super.request(params, options, callback)) as TransportRequestPromise<
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          ApiResponse<Record<string, any>, Record<string, unknown>>
+        >
       }
 
-      return super.request(params, options, callback)
-    })
-  }
+      // Wrap callback API
+      credentials.get(err => {
+        if (err) {
+          callback(err, null)
+          return
+        }
+
+        return super.request(params, options, callback)
+      })
+    }
+  };
 }
 
-export function createAWSConnection(awsCredentials: Credentials) {
-  AWSConnection.prototype.awsCredentials = awsCredentials
-  return { Connection: AWSConnection, Transport: AWSTransport }
+export function createAWSConnection(awsCredentials: Credentials): ClientOptions {
+  return {
+    Connection: generateAWSConnectionClass(awsCredentials),
+    Transport: generateAWSTransportClass(awsCredentials)
+  }
 }
 
 export const awsGetCredentials = (): Promise<Credentials> => {


### PR DESCRIPTION
This enables the AWS connection to work with multiple different credentials instead of using only AWS global config for credentials.