### PR TITLE
add service param to signing call to allow for non-aws hostnames

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -12,7 +12,7 @@ function generateAWSConnectionClass(credentials: Credentials) {
     }
 
     private signedRequest(reqParams: ClientRequestArgs): ClientRequest {
-      return request(sign(reqParams, credentials))
+      return request(sign({ ...reqParams, service: 'es' }, credentials))
     }
   }
 }


### PR DESCRIPTION
This will bypass the signing service attempting to auto-derive the service from the given hostname. 

This will address https://github.com/mergermarket/acuris-aws-es-connection/issues/43