### PR TITLE
Respect protocol when constructing the HTTP(s) request

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,6 @@
 import { config, Credentials } from 'aws-sdk/global'
-import { request, ClientRequest, ClientRequestArgs } from 'http'
+import { request as httpRequest, ClientRequest, ClientRequestArgs } from 'http'
+import { request as httpsRequest } from 'https'
 import { sign } from 'aws4'
 import { ClientOptions, Connection, Transport } from '@elastic/elasticsearch'
 import { ApiResponse, TransportRequestPromise } from '@elastic/elasticsearch/lib/Transport'
@@ -12,6 +13,8 @@ function generateAWSConnectionClass(credentials: Credentials) {
     }
 
     private signedRequest(reqParams: ClientRequestArgs): ClientRequest {
+      const request = reqParams?.protocol === 'https:' ? httpsRequest : httpRequest
+
       return request(sign({ ...reqParams, service: 'es' }, credentials))
     }
   }


### PR DESCRIPTION
## Steps
Construct a client using:
- [@elastic/elasticsearch](https://www.npmjs.com/package/@elastic/elasticsearch)
- [@acuris/aws-es-connection](https://www.npmjs.com/package/@acuris/aws-es-connection)
- [appdynamics](https://www.npmjs.com/package/appdynamics)

Issue a sample request to an Elasticsearch cluster through HTTPS.

Expected: The request succeeds
Actual: The request fails (port `80` is used)

### More info
`appdynamics` hooks before the request is send and based on the module name (in our case - always `http`) proxies the request through port `80` instead of `443`. Explicitly setting the port to `443` doesn't work either.

Although this may be handled and fixed in the `appdynamics` package, the fix here is pretty trivial and it seems kinda logical to use the proper `http` or `https` module. Con of this approach is that the logic of using `http`/`https` resides in 2 places now - `@elastic/elasticsearch` and `@acuris/aws-es-connection`.