### PR TITLE
Improvement/add regions option support

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -6,8 +6,8 @@ import { ClientOptions, Connection, Transport } from '@elastic/elasticsearch'
 import { ApiResponse, TransportRequestPromise } from '@elastic/elasticsearch/lib/Transport'
 
 declare type SignOpt = {
-  service: string;
-  region: string;
+  service: 'es';
+  region?: string;
 }
 
 function generateAWSConnectionClass(credentials: Credentials, signOpts?: SignOpt) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -59,9 +59,9 @@ function generateAWSTransportClass(credentials: Credentials) {
   };
 }
 
-export function createAWSConnection(awsCredentials: Credentials): ClientOptions {
+export function createAWSConnection(awsCredentials: Credentials, signOpts?: SignOpt): ClientOptions {
   return {
-    Connection: generateAWSConnectionClass(awsCredentials),
+    Connection: generateAWSConnectionClass(awsCredentials, signOpts),
     Transport: generateAWSTransportClass(awsCredentials)
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,7 +5,12 @@ import { sign } from 'aws4'
 import { ClientOptions, Connection, Transport } from '@elastic/elasticsearch'
 import { ApiResponse, TransportRequestPromise } from '@elastic/elasticsearch/lib/Transport'
 
-function generateAWSConnectionClass(credentials: Credentials) {
+declare type SignOpt = {
+  service: string;
+  region: string;
+}
+
+function generateAWSConnectionClass(credentials: Credentials, signOpts?: SignOpt) {
   return class AWSConnection extends Connection {
     public constructor(opts) {
       super(opts)
@@ -15,7 +20,7 @@ function generateAWSConnectionClass(credentials: Credentials) {
     private signedRequest(reqParams: ClientRequestArgs): ClientRequest {
       const request = reqParams?.protocol === 'https:' ? httpsRequest : httpRequest
 
-      return request(sign({ ...reqParams, service: 'es' }, credentials))
+      return request(sign({ ...reqParams, service: 'es', ...signOpts }, credentials))
     }
   }
 }


### PR DESCRIPTION
### Description
This PR adresses the issue with `aws4` package usage, when it tries to get the **AWS Region** from the hostname.
### Use Case
When the **AWS Elasticsearch** domain is under a custom domain the signature won't be valid. If the node is hosted in another region than `us-east-1`

eg.

- Expected domain  _Resulting Signature Valid ✅_
`https://xxxx.<region>.es.amazonaws.com`

- Aliased Domain _Resulting Signature Invalid ❌_
`https://search.mydomain.com`

Snippet responsible for the region in `aws4` 
````
this.region = request.region || hostParts[1] || 'us-east-1'
````

### Resolution
Adding `signOpt` as an optional param to generateAWSConnectionClass

````
declare type SignOpt = {
  service: 'es';
  region?: string;
}

function generateAWSConnectionClass(credentials: Credentials, signOpts?: SignOpt)
````